### PR TITLE
Fix race condition in file permission check

### DIFF
--- a/samples/sample_kcl.rb
+++ b/samples/sample_kcl.rb
@@ -39,7 +39,7 @@ class SampleRecordProcessor < Aws::KCLrb::RecordProcessorBase
       FileUtils.mkdir_p @output_directory
       probe_file = File.join(@output_directory, '.kclrb_probe')
       FileUtils.touch(probe_file)
-      FileUtils.rm(probe_file)
+      FileUtils.rm(probe_file, :force => true)
     elsif output
       # assume it's an IO
       @output = output


### PR DESCRIPTION
When one process deletes the `probe_file`, another process is then unable to delete that file.
With the `:force => true` option this will not raise an `Errno::ENOENT` exception so this problem
will not cause the processor to halt.