### PR TITLE
Made /samples code descriptive and use new aws-sdk gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,11 @@
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
+.ruby-gemset
+.ruby-version
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To run the data processor, run the following commands:
 
 ```sh
     cd samples
-    rake run properties_file=sample.properties
+    rake run_consumer properties_file=sample.properties
 ```
 
 #### Notes
@@ -157,7 +157,7 @@ Amazon Linux can be found at `/usr/bin/java` and should be 1.7 or greater.
     cd kclrb/samples
     rake run_producer
     # ... and in another terminal
-    rake run properties_file=sample.properties
+    rake run_consumer properties_file=sample.properties
 ```
 
 ## Under the Hood - What You Should Know about Amazon KCL's [MultiLangDaemon][multi-lang-daemon]

--- a/aws-kclrb.gemspec
+++ b/aws-kclrb.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.files          += ['README.md', 'LICENSE.txt', 'VERSION', 'NOTICE.txt', '.yardopts', '.rspec']
   spec.licenses         = ['Apache-2.0']
   spec.platform        = Gem::Platform::RUBY
-  spec.homepage        = 'http://github.com/aws/amazon-kinesis-client-ruby'
+  spec.homepage        = 'https://github.com/awslabs/amazon-kinesis-client-ruby'
   spec.require_paths   = ['lib']
 
   spec.add_dependency('multi_json', '~> 1.0')

--- a/samples/Gemfile
+++ b/samples/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'aws-sdk', '~> 3.0', '>= 3.0.1'
+gem 'multi_json', '~> 1.13', '>= 1.13.1'
+gem 'pry', '~> 0.12.2'
+gem 'pry-byebug', '~> 3.7'
+gem 'byebug', '~> 11.0', '>= 11.0.1'
+gem 'aws-kclrb', '~> 2.0'

--- a/samples/Rakefile
+++ b/samples/Rakefile
@@ -1,8 +1,9 @@
 #
 #  Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-
 require 'open-uri'
+require 'byebug'
+require 'pathname'
 
 SAMPLES_DIR = File.dirname(__FILE__)
 JAR_DIR = File.join(SAMPLES_DIR, 'jars')
@@ -90,10 +91,12 @@ MAVEN_PACKAGES = [
     ['commons-collections', 'commons-collections', '3.2.2']
 ]
 
+desc "download jar files"
 task :download_jars => [JAR_DIR]
 
 MAVEN_PACKAGES.each do |jar|
   _, _, local_jar_file = get_maven_jar_info(*jar)
+  #desc "downlods jar file"
   file local_jar_file do
     puts "Downloading '#{local_jar_file}' from maven..."
     download_maven_jar(*jar)
@@ -110,12 +113,13 @@ task :run_producer do |t|
   sh *commands
 end
 
-desc "Run KCL sample processor"
-task :run => :download_jars do |t|
+desc "Run KCL sample processor aka consumer"
+task :run_consumer => :download_jars do |t|
   java_home = ENV['JAVA_HOME']
   fail "JAVA_HOME environment variable not set." unless java_home
   properties_file = ENV['properties_file']
-  unless properties_file
+  properties_file = './sample.properties' if properties_file.nil?
+  unless Pathname.new(properties_file).exist?
     fail "Properties file not provided. Use \"rake run properties_file=<PATH_TO_FILE> to provide it.\""
   end
   log_configuration = ENV['log_configuration']

--- a/samples/sample_kcl_producer.rb
+++ b/samples/sample_kcl_producer.rb
@@ -3,9 +3,9 @@
 #  Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-require 'aws-sdk-core'
 require 'multi_json'
 require 'optparse'
+require 'aws-sdk'
 
 # @api private
 class SampleProducer


### PR DESCRIPTION
*Issue #, if available:* 7

*Description of changes:*

Fixed homepage Url in gemspec for npmjs
added gemfile in samples directory to manage gems needed to run sample
added description to rake tasks to make samples more descriptive
added default for sample.properties
uses correct updated aws-sdk gem instead of aws-sdk-core
updated readme to say rake run_consumer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
