### PR TITLE
Update dependabot.yml to use bundler package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
+  - package-ecosystem: "bundler"
     directory: "/"
     schedule: 
       interval: "weekly"


### PR DESCRIPTION
Updated package ecosystem to Ruby's bundler to allow dependabot alerts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
