### PR TITLE
Bumped netty to 4.1.100.Final, fasterxml-jackson to 2.13.5, and guava to 32.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <properties>
         <awssdk.version>2.19.2</awssdk.version>
         <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
         <logback.version>1.3.0</logback.version>
     </properties>
     <dependencies>
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>32.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Bump com.fasterxml.jackson.core:jackson-databind from 2.13.4 to 2.13.5
Bump io.netty:netty-codec-http2 from 4.1.86.Final to 4.1.100.Final
Bump com.google.guava:guava from 31.0.1-jre to 32.1.1-jre



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
