### PR TITLE
Prepare for KCL Ruby Release 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ all languages.
 
 ## Release Notes
 ### Release 2.1.2 (January 22, 2025)
-* [#69](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/69) Include `pom.xml` in the gemspec
+* Upgraded to use version 2.6.1 of the [Amazon Kinesis Client library](https://github.com/awslabs/amazon-kinesis-client/blob/v2.6.1/CHANGELOG.md#release-261-2024-12-13).
 
 ### Release 2.1.1 (February 21, 2023)
 * [#69](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/69) Include `pom.xml` in the gemspec


### PR DESCRIPTION
*Issue #, if available:* N/A 

*Description of changes:*
* Update README for v2.1.2 
* Upgrade dependencies for KCL v2.6.1. See the commit [here](https://github.com/awslabs/amazon-kinesis-client-ruby/commit/7770c82375461eaaebfd46743101a5294b78236d).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
