### PR TITLE
Upgrade dependencies for netty and logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <kcl.version>3.0.0</kcl.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.3.14</logback.version>
+        <logback.version>1.5.16</logback.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Upgrading dependencies for:
* netty (4.1.108.Final to 4.1.118.Final)
* logback (1.3.14 to 1.5.16)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
