### PR TITLE
Update v2.x dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-codec-base</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
             <version>${netty.version}</version>
         </dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating dependencies for KCL Ruby v2.x

* Bump KCL version from 2.7.0 to latest 2.7.2
* Bump AWS SDK version from 2.25.64 to 2.33.0
* Bump Apache commons-lang3 from 3.14.0 to 3.18.0
* Bump netty version from 4.1.118 to 4.2.4.Final
* Bump fasterxml-jackson from 2.13.15 to 2.15.0



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
