### PR TITLE
Upgrade dependencies for 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <awssdk.version>2.25.64</awssdk.version>
-        <kcl.version>3.0.0</kcl.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <awssdk.version>2.33.0</awssdk.version>
+        <kcl.version>3.1.3</kcl.version>
+        <netty.version>4.2.4.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
         <logback.version>1.3.15</logback.version>
     </properties>
     <dependencies>
@@ -183,6 +183,16 @@
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
@@ -195,6 +205,11 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-base</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
@@ -260,7 +275,7 @@
         <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
-            <version>2.5.2</version>
+            <version>3.49.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.errorprone</groupId>
@@ -285,7 +300,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Upgrade amazon-kinesis-client from 3.0.0 to 3.1.3
* Upgrade aws-sdk from 2.25.64 to 2.33.0
* Upgrade netty.version from 4.1.118.Final to 4.2.4.Final
* Upgrade fasterxml-jackson from 2.13.5 to 2.15.0
* Upgrade checker-qual from 2.5.2 to 3.49.4
* Upgrade org.apache.commons:commons-lang3 from 3.14.0 to 3.18.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
